### PR TITLE
Added “recipient” field, to notify the intended recipient on IRC

### DIFF
--- a/pasterack.rkt
+++ b/pasterack.rkt
@@ -411,6 +411,12 @@
                           [style ,(~~ "background-color:#FFFFF0"
                                       "border:inset thin"
                                       "font-size:105%"
+                                      "font-family:'PT Sans',sans-serif")]))
+                  (span "; recipient's nick: ")
+                  (input ([type "text"] [name "recipient"] [size "10"]
+                          [style ,(~~ "background-color:#FFFFF0"
+                                      "border:inset thin"
+                                      "font-size:105%"
                                       "font-family:'PT Sans',sans-serif")])))))
             (span ,status)
             (br)
@@ -499,7 +505,11 @@
                               'views 0))
     (when (exists-binding? 'irc bs)
       (define nick (extract-binding/single 'nick bs))
-      (irc-paste (++ (if (string=? "" nick) "" (++ nick " pasted: "))
+      (define recipient (if (exists-binding? 'recipient bs)
+                            (extract-binding/single 'recipient bs)
+			    ""))
+      (irc-paste (++ (if (string=? "" recipient) "" (++ recipient ": "))
+                     (if (string=? "" nick) "" (++ nick " pasted: "))
                      (if (string=? "" paste-name) "" (++ paste-name ", "))
                      paste-url)))
     (fprintf log-port "~a\t~a\t~a\t~a\n"


### PR DESCRIPTION
I added a `recipient` field along the existing `nick` one, so that pasterack writes on IRC messages of the form:

```
recipient: my-nick pasted: http://…
```

I just realized however that one could also just write "recipient: my-nick" inside the `nick` field with the existing version, which is less semantic but gives the same exact result, so maybe this patch is superfluous.
