### PR TITLE
Added a restful API at "…/rest" (implements #48)

### DIFF
--- a/pasterack.rkt
+++ b/pasterack.rkt
@@ -437,6 +437,17 @@
          ))))
   (send/suspend/dispatch response-generator))
 
+(define (check-paste-check-bindings request)
+  (define bs (request-bindings request))
+  (if (and (andmap (λ (b) (exists-binding? b bs))
+                   '(name g-recaptcha-response paste fork-from))
+           (implies (exists-binding? 'irc bs)
+                    (exists-binding? 'nick bs)))
+      (check-paste request)
+      (response/xexpr
+       `(html ()
+          (head ())
+          (body () "ERROR: bad paste" ,(mk-link pastebin-url "Go Back"))))))
 (define (check-paste request)
   (define bs (request-bindings request))
   (define name (extract-binding/single 'name bs))
@@ -750,6 +761,7 @@
 (define-values (do-dispatch mk-url)
   (dispatch-rules
    [("") serve-home]
+   [("rest") #:method "post" check-paste-check-bindings]
    [("pastes" (string-arg)) serve-paste]
    [("tests") serve-tests]
    [("bacon") serve-bacon]


### PR DESCRIPTION
The API accepts the same POST parameters as when using the main page, but doesn't require a continuation.

```
curl 'http://127.0.0.1:8000/rest' -H 'Content-Type: application/x-www-form-urlencoded' --data 'name=test&paste=%23lang+racket%0D%0A%28displayln+%27yay%29&fork-from=&g-recaptcha-response='
```

All the above parameters are mandatory, and the presence of the `irc` parameter implies the presence of the `nick` parameter:

```
curl 'http://127.0.0.1:8000/rest' -H 'Content-Type: application/x-www-form-urlencoded' --data 'name=test&paste=%23lang+racket%0D%0A%28displayln+%27yay%29&fork-from=&irc=&nick=georges-duperon&g-recaptcha-response='
```

I haven't tested this thoroughly as I don't have a propper `redis` setup. With the additionnal parameter checking, I don't see any added security concern, but please do double-check the security aspect before merging.
